### PR TITLE
One User Submission Per Festival

### DIFF
--- a/src/commands/SubmitSetCommand.ts
+++ b/src/commands/SubmitSetCommand.ts
@@ -67,6 +67,13 @@ export default class SubmitSetCommand {
 		festivalId: string,
 		interaction: CommandInteraction
 	) {
+		if (await this.festivalSetService.hasUserAlreadySubmittedSetForFestival(interaction.user.id, festivalId)) {
+			return interaction.reply({
+				content: "You have already submitted a set for this festival.",
+				ephemeral: true
+			});
+		}
+
 		await interaction.showModal(this.getModal({ name: interaction.user.displayName }));
 
 		const submission = await interaction.awaitModalSubmit({

--- a/src/services/FestivalSetService.ts
+++ b/src/services/FestivalSetService.ts
@@ -1,7 +1,10 @@
 import { injectable as Injectable } from "tsyringe";
+import { Types } from "mongoose";
 import { FestivalSetRepository } from "../repositories/FestivalSetRepository";
 import { FestivalSetModel } from "../models/FestivalSetModel";
 import { FestivalRepository } from "../repositories/FestivalRepository";
+
+const ObjectId = Types.ObjectId;
 
 @Injectable()
 export default class FestivalSetService {
@@ -25,5 +28,14 @@ export default class FestivalSetService {
 			festival,
 			...set
 		})
+	}
+
+	async hasUserAlreadySubmittedSetForFestival(userId: string, festivalId: string): Promise<boolean> {
+		const festivals = await this.festivalSetRepository.getAll({
+			user_id: userId,
+			festival: new ObjectId(festivalId)
+		});
+
+		return festivals.length > 0;
 	}
 }


### PR DESCRIPTION
Stop users from being able to submit multiple sets for a given festival. This is also enforced by a unique compound index on `user_id` and `event_id`.